### PR TITLE
Handling more than one image uploaded on updated state

### DIFF
--- a/api/modules/Photo/controller.js
+++ b/api/modules/Photo/controller.js
@@ -2,6 +2,7 @@
 import Photo from './model';
 import '../../config/cloudinaryConfig';
 
+// Takes in Cloudinary Data and stores on DB.
 export const getPublicID = (req, res) => {
   const data = req.body.result; // this should be an array of object(s)
   console.log('REQUEST FROM FRONT-END');
@@ -32,6 +33,7 @@ export const getPublicID = (req, res) => {
     );
 };
 
+// Calls up specific data for rendering on the front-end.
 export const sendToFrontEnd = (req, res) => {
   /* TODO: request from front-end should ask for:
       1) All images.

--- a/client/src/modules/photobooth/actions.js
+++ b/client/src/modules/photobooth/actions.js
@@ -5,7 +5,7 @@ import { fetchFromBackEnd, sendToBackEnd } from './apiMethods';
 export const getCloudinaryData = (error, result) => (
   {
     type: CLOUDINARY_DATA,
-    promise: sendToBackEnd(result),
+    promise: sendToBackEnd(result), // POST Request to API Server
     meta: {
       onFailure: () => toastr.warning('Failure!', 'Upload Failed!'),
       onSuccess: () => toastr.success('Success!', 'Successfully Uploaded!')
@@ -16,7 +16,7 @@ export const getCloudinaryData = (error, result) => (
 export const getFromBackEnd = () => (
   {
     type: DATABASE_IMAGES,
-    promise: fetchFromBackEnd(),
+    promise: fetchFromBackEnd(), // GET Request to API Server
     meta: {
       onFailure: () => toastr.warning('Failure!', 'Database Error.'),
     }

--- a/client/src/modules/photobooth/apiMethods.js
+++ b/client/src/modules/photobooth/apiMethods.js
@@ -5,6 +5,8 @@ export const sendToBackEnd = result => {
     axios.post('/library', { result })
       .then(
         res => {
+          // array of object(s)...images
+          // this holds the data from the Cloudinary response.
           resolve(res.data.cloudinary);
         },
         err => reject(err)
@@ -18,6 +20,8 @@ export const fetchFromBackEnd = () => {
     axios.get('/library')
       .then(
         res => {
+          // array of object(s)...images
+          // this holds the data from mongo DB
           resolve(res.data.payload);
         },
         err => {

--- a/client/src/modules/photobooth/apiMethods.js
+++ b/client/src/modules/photobooth/apiMethods.js
@@ -1,33 +1,9 @@
 import axios from 'axios';
 
-export const sendToBackEnd = result => {
-  const promise = new Promise((resolve, reject) => {
-    axios.post('/library', { result })
-      .then(
-        res => {
-          // array of object(s)...images
-          // this holds the data from the Cloudinary response.
-          resolve(res.data.cloudinary);
-        },
-        err => reject(err)
-      );
-  });
-  return promise;
-};
+export const sendToBackEnd = result => (
+  axios.post('/library', { result })
+);
 
-export const fetchFromBackEnd = () => {
-  const promise = new Promise((resolve, reject) => {
-    axios.get('/library')
-      .then(
-        res => {
-          // array of object(s)...images
-          // this holds the data from mongo DB
-          resolve(res.data.payload);
-        },
-        err => {
-          reject(err);
-        }
-      );
-  });
-  return promise;
-};
+export const fetchFromBackEnd = () => (
+  axios.get('/library')
+);

--- a/client/src/modules/photobooth/library/Library.jsx
+++ b/client/src/modules/photobooth/library/Library.jsx
@@ -12,18 +12,18 @@ class Library extends Component {
     if (!photos.isFetched) return <LoadingScreen />;
 
     // Where array of object(s) is processed for rendering/re-rendering.
-    const images = photos.server.reduce((array, item, index) => {
-      const { url } = item;
+    const images = photos.server.reduce((array, item) => {
+      const { _id, url } = item;
       if (!url) {
         array.push(
-          <Image key={index} size='tiny'>
+          <Image key={_id} size='tiny'>
             <Label content='Image not found!' icon='warning' />
           </Image>
         );
       }
       array.push(
         <Image
-          key={index}
+          key={_id}
           src={url}
         />
       );

--- a/client/src/modules/photobooth/library/Library.jsx
+++ b/client/src/modules/photobooth/library/Library.jsx
@@ -4,12 +4,14 @@ import { LoadingScreen } from '../../../commons';
 
 class Library extends Component {
   componentWillMount() {
+    // perform GET Request for appending images.
     this.props.getFromBackEnd();
   }
   render() {
     const { photos, translate } = this.props;
     if (!photos.isFetched) return <LoadingScreen />;
 
+    // Where array of object(s) is processed for rendering/re-rendering.
     const images = photos.server.reduce((array, item, index) => {
       const { url } = item;
       if (!url) {

--- a/client/src/modules/photobooth/library/LibraryContainer.jsx
+++ b/client/src/modules/photobooth/library/LibraryContainer.jsx
@@ -11,3 +11,5 @@ export default connect(
   mapStateToProps,
   { getFromBackEnd }
 )(withTranslate(Library));
+
+// connect Library to Redux Store & pass translate() to component.

--- a/client/src/modules/photobooth/reducers.js
+++ b/client/src/modules/photobooth/reducers.js
@@ -21,6 +21,8 @@ export default (state = initialState, action) => {
           ...s,
           message: 'Upload Successful!',
           cloudinary: payload,
+          // only will append one image on re-render due to state change.
+          // even when more than one image has been uploaded.
           server: [...s.server, { url: payload[0].url, _id: payload[0]._id }]
         }),
       });

--- a/client/src/modules/photobooth/reducers.js
+++ b/client/src/modules/photobooth/reducers.js
@@ -21,9 +21,7 @@ export default (state = initialState, action) => {
           ...s,
           message: 'Upload Successful!',
           cloudinary: payload,
-          // only will append one image on re-render due to state change.
-          // even when more than one image has been uploaded.
-          server: [...s.server, { url: payload[0].url, _id: payload[0]._id }]
+          server: [...s.server, ...payload.data.cloudinary]
         }),
       });
     case DATABASE_IMAGES:
@@ -33,7 +31,7 @@ export default (state = initialState, action) => {
         failure: s => ({ ...s, error: true, message: '' }),
         success: s => ({
           ...s,
-          server: payload
+          server: payload.data.payload
         }),
       });
     default:


### PR DESCRIPTION
The current configuration of the _photoReducer_ will render the first index of the array which is fine and works as it should; however should the user upload more than one image to Cloudinary the database receives more than one image object.

```javascript
success: s => ({
          ...s,
          message: 'Upload Successful!',
          cloudinary: payload,
          // only will append one image on re-render due to state change.
          // even when more than one image has been uploaded.
          server: [...s.server, { url: payload[0].url, _id: payload[0]._id }]
        }),
```

Trying to find a way to handle this (& the best place to do so) so that should the user upload more than one image when the component re-renders due to state change all the _new_ images are shown, not just `payload[0]`.

At the moment a page refresh causes `componentWillMount()` to fire rendering all images in the database; but obviously I don't want my user having to refresh the page every time they add image(s) so they can see all the new image(s).

The thing I'm struggling to wrap my head around is in all case I will be getting an array of object(s) back that I want to _concat_ with the previous _state_ on `server`. I would think doing a `reduce()` would be the way to go so I only am getting an array of object(s) with these two properties on them; but I would still be stuck trying to loop through the array to _concat_ the two states.

Any ideas on how to handle this gracefully and where the best place to handle this would be?

- [ ]  reducer
- [ ] action
- [ ] apiMethod
- [ ] backend
